### PR TITLE
Custom ActionID

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -296,10 +296,15 @@ function AMI(hostname, port, username, password){
             cb = (typeof cb == 'function') ? cb : new Function();
 
         data.Action = null;
-        data.ActionID = null;
+        //ALLOW USING OWN ACTION ID
+        if(typeof data.ActionID === 'undefined') {
+                data.ActionID = null;
+                dataJson.ActionID = actionIDGenerator();
+        }
+        //END ALLOW USING OWN ACTION ID
 
         dataJson.Action = name;
-        dataJson.ActionID = actionIDGenerator();
+        //dataJson.ActionID = actionIDGenerator();
 
         for(var x in data){
             if(data[x]){


### PR DESCRIPTION
Enable the feature to provide custom ActionID instead
of generating one every time an action is created.
