### PR TITLE
Better Handle of AMI Events

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -170,8 +170,10 @@ AMIParser.prototype._transform = function(chunk, encoding, done){
             }
 
             // test what type of message we have: response or event
-            if(messajeJson['Response'] && messajeJson['ActionID']){
-                // this is a response of on action
+            if(messajeJson['Response'] && messajeJson['ActionID'] && messajeJson['Event'] ){
+                // this is an event
+                this.emit('event', messajeJson);
+            } else if(messajeJson['Response'] && messajeJson['ActionID'] ){
                 this.emit('response', messajeJson);
             } else if(messajeJson['Event']){
                 // this is an event


### PR DESCRIPTION
Before every ami Event that had Response in it was being handle as a response, but
Originate Action, generates and Event with Response, which ami.on("eventOriginateResponse") was failing to recognise.
Therefore, adding a new if, that checks when the data from AMI has, Response Action and Event emits an event and not
a response.
