### PR TITLE
Always emit an eventEventName, even for responses, if they have an event name

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -173,7 +173,9 @@ AMIParser.prototype._transform = function(chunk, encoding, done){
             if(messajeJson['Response'] && messajeJson['ActionID']){
                 // this is a response of on action
                 this.emit('response', messajeJson);
-            } else if(messajeJson['Event']){
+            }
+
+            if(messajeJson['Event']){
                 // this is an event
                 this.emit('event', messajeJson);
             }


### PR DESCRIPTION
This addresses the issue where OriginateResponse-events wasn't emitted. If a message from Asterisk contains the Event-field, then it's an event and should be emitted.